### PR TITLE
Submodule `edge` updated to Tidal Plugin 0.8.9.2 (Hotfix)

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ release|tidal|0.8.6
 master|subsonic|0.8.6
 master|tidal|0.8.9.1
 edge|subsonic|0.8.7
-edge|tidal|0.8.9.1
+edge|tidal|0.8.9.2
 
 ### Support for HiRes Tidal
 

--- a/doc/change-history.md
+++ b/doc/change-history.md
@@ -2,6 +2,7 @@
 
 Change Date|Major Changes
 ---|---
+2025-07-27|Submodule `edge` updated to Tidal Plugin 0.8.9.2 (Hotfix)
 2025-07-26|Submodule `edge` updated to Subsonic Plugin 0.8.7
 2025-07-14|Submodule `master` updated to Subsonic Plugin 0.8.6
 2025-07-14|Submodule `edge` updated to Subsonic Plugin 0.8.6


### PR DESCRIPTION
This solves issue [#546](https://github.com/GioF71/upmpdcli-docker/issues/546) and [this one](https://github.com/GioF71/upmpdcli-plugins/issues/34) I created to keep track of changes.