### PR TITLE
#650 Submodule `edge` updated to Subsonic Plugin 0.9.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ release|mother earth radio|0.0.5
 master|subsonic|0.9.9
 master|tidal|0.8.12
 master|mother earth radio|0.0.5
-edge|subsonic|0.9.9
+edge|subsonic|0.9.10
 edge|tidal|0.8.12
 edge|mother earth radio|0.0.5
 

--- a/doc/change-history.md
+++ b/doc/change-history.md
@@ -2,6 +2,7 @@
 
 Change Date|Major Changes
 ---|---
+2026-04-18|Submodule `edge` updated to Subsonic Plugin 0.9.10
 2026-04-18|Submodules `release`, `master` and `edge` updated to upmpdcli 1.9.17
 2026-04-16|Submodules `release`, `master` and `edge` updated to upmpdcli 1.9.16
 2026-04-02|Submodule `edge` updated to Subsonic Plugin 0.9.9


### PR DESCRIPTION
Subsonic Plugin Release 0.9.10

- Merge album versions by default (allowmixalbumversions), selecting best track by disc number / track number using quality metadata
- Strip version from album as we already handle version separately (can be disabled setting stripversionfromtitle to 0)
- General code cleanup, fixes and optimizations
