### PR TITLE
Submodule `master` updated to Subsonic Plugin 0.9.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,10 +38,10 @@ BUILD_TYPE|PLUGIN|VERSION
 release|subsonic|0.9.9
 release|tidal|0.8.12
 release|mother earth radio|0.0.5
-master|subsonic|0.9.9
+master|subsonic|0.9.11
 master|tidal|0.8.12
 master|mother earth radio|0.0.5
-edge|subsonic|0.9.10
+edge|subsonic|0.9.11
 edge|tidal|0.8.12
 edge|mother earth radio|0.0.5
 

--- a/app/install/install-mediaserver-python-packages-subsonic.sh
+++ b/app/install/install-mediaserver-python-packages-subsonic.sh
@@ -6,8 +6,8 @@ if [[ "${BUILD_MODE}" = "full" ]]; then
     if [[ "${UPMPDCLI_SELECTOR}" == "edge" ]]; then
         pip install --break-system-packages subsonic-connector==0.3.12 python-dateutil python-dotenv
     elif [[ "${UPMPDCLI_SELECTOR}" == "master" ]]; then
-        pip install --break-system-packages subsonic-connector==0.3.11 python-dateutil python-dotenv
+        pip install --break-system-packages subsonic-connector==0.3.12 python-dateutil python-dotenv
     else
-        pip install --break-system-packages subsonic-connector==0.3.11 python-dateutil python-dotenv
+        pip install --break-system-packages subsonic-connector==0.3.12 python-dateutil python-dotenv
     fi
 fi

--- a/doc/change-history.md
+++ b/doc/change-history.md
@@ -2,7 +2,7 @@
 
 Change Date|Major Changes
 ---|---
-2026-04-19|Submodule `edge` updated to Subsonic Plugin 0.9.11
+2026-04-19|Submodule `edge` and `master` updated to Subsonic Plugin 0.9.11
 2026-04-18|Submodule `edge` updated to Subsonic Plugin 0.9.10
 2026-04-18|Submodules `release`, `master` and `edge` updated to upmpdcli 1.9.17
 2026-04-16|Submodules `release`, `master` and `edge` updated to upmpdcli 1.9.16


### PR DESCRIPTION
- master and release builds to use subsonic-connector 0.3.12 (backwards-compatible)