### PR TITLE
Submodule `edge` updated to Subsonic Plugin 0.9.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ release|mother earth radio|0.0.5
 master|subsonic|0.9.11
 master|tidal|0.8.12
 master|mother earth radio|0.0.5
-edge|subsonic|0.9.11
+edge|subsonic|0.9.12
 edge|tidal|0.8.12
 edge|mother earth radio|0.0.5
 

--- a/doc/change-history.md
+++ b/doc/change-history.md
@@ -2,6 +2,7 @@
 
 Change Date|Major Changes
 ---|---
+2026-04-20|Submodule `edge` updated to Subsonic Plugin 0.9.12
 2026-04-19|Submodule `edge` and `master` updated to Subsonic Plugin 0.9.11
 2026-04-18|Submodule `edge` updated to Subsonic Plugin 0.9.10
 2026-04-18|Submodules `release`, `master` and `edge` updated to upmpdcli 1.9.17


### PR DESCRIPTION
Subsonic Plugin Release 0.9.12

- More support for music folder id, hopefully complete now (see [this issue](https://github.com/GioF71/upmpdcli-plugins/issues/40))
- Remove now unused method for setting album metadata
- General code cleanup, fixes and optimizations