### PR TITLE
#657 Subsonic Plugin Release 0.9.13

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ release|mother earth radio|0.0.5
 master|subsonic|0.9.11
 master|tidal|0.8.12
 master|mother earth radio|0.0.5
-edge|subsonic|0.9.12
+edge|subsonic|0.9.13
 edge|tidal|0.8.12
 edge|mother earth radio|0.0.5
 

--- a/doc/change-history.md
+++ b/doc/change-history.md
@@ -2,6 +2,7 @@
 
 Change Date|Major Changes
 ---|---
+2026-04-26|Submodule `edge` updated to Subsonic Plugin 0.9.13
 2026-04-20|Submodule `edge` updated to Subsonic Plugin 0.9.12
 2026-04-19|Submodule `edge` and `master` updated to Subsonic Plugin 0.9.11
 2026-04-18|Submodule `edge` updated to Subsonic Plugin 0.9.10


### PR DESCRIPTION
- Add mood metadata also at track level
- Add Resolution to album property keys
- AlbumBrowser key selection improved
- Improve browsing when preloading is still in progress
- Merge album versions now also uses the track title as key (and also replaces some weird chars, more work is likely to be needed)
- More sensible sorting and formatting methods for bit depths and sampling rates
- Artist Roles uses artist_sort_name instead of artist_name
- Avoid artist_sort_name to be null with new migration (set to artist_name if null)
- Album Browser: label initial to be upper case
- Add new view "Albums with duplicate titles" in Artist view (can be disabled with allowartistduplicatealbumtitle)
- Add new view "Albums with duplicate title/version pairs" in Artist view (can be disabled with allowartistduplicatealbumtitleversion)
- General code cleanup, fixes and optimizations