### PR TITLE
Submodule `edge` updated to Subsonic Plugin 0.9.14

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ release|mother earth radio|0.0.5
 master|subsonic|0.9.13
 master|tidal|0.8.12
 master|mother earth radio|0.0.5
-edge|subsonic|0.9.13
+edge|subsonic|0.9.14
 edge|tidal|0.8.12
 edge|mother earth radio|0.0.5
 

--- a/doc/change-history.md
+++ b/doc/change-history.md
@@ -2,6 +2,7 @@
 
 Change Date|Major Changes
 ---|---
+2026-05-04|Submodule `edge` updated to Subsonic Plugin 0.9.14
 2026-05-04|Submodule `master` updated to Subsonic Plugin 0.9.13
 2026-05-04|Avoid chown on /user/config (not needed) (see [#662](https://github.com/GioF71/upmpdcli-docker/issues/662))
 2026-05-03|A few improvements to the startup script (see [this issue](https://framagit.org/medoc92/upmpdcli/-/issues/164))


### PR DESCRIPTION
Subsonic Plugin Release 0.9.14

- Initial support for replay gain
- Album track quality summary column is now populated also during initialization phase
- Execute initial_caching after setup operations (avoid a closed database exception)
- General code cleanup, fixes and optimizations
