### PR TITLE
#678 Submodule master updated to Subsonic Plugin 0.9.15 (#677)

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ BUILD_TYPE|PLUGIN|VERSION
 release|subsonic|0.9.9
 release|tidal|0.8.12
 release|mother earth radio|0.0.5
-master|subsonic|0.9.14
+master|subsonic|0.9.15
 master|tidal|0.8.12
 master|mother earth radio|0.0.5
 edge|subsonic|0.9.15

--- a/doc/change-history.md
+++ b/doc/change-history.md
@@ -2,6 +2,7 @@
 
 Change Date|Major Changes
 ---|---
+2026-07-04|Submodule `master` updated to Subsonic Plugin 0.9.15 (see [#678](https://github.com/GioF71/upmpdcli-docker/issues/678))
 2026-07-02|Submodule `edge` updated to Subsonic Plugin 0.9.15 (see [#676](https://github.com/GioF71/upmpdcli-docker/issues/676))
 2026-05-12|Information for retrieving a PKCE credentials file (see [#672](https://github.com/GioF71/upmpdcli-docker/issues/672))
 2026-05-09|Changes for new qobuz authentication method (see [#670](https://github.com/GioF71/upmpdcli-docker/issues/670))


### PR DESCRIPTION
Subsonic Plugin Release 0.9.15

Execute vacuum is now disabled by default (slows down initialization) Some more technical album property key are disabled by default: Label Initial, Has Cover Art, Has MusicBrainz Each album property key has a raw key, defined by property name to lowercase and without underscores Example raw property key for HAS_COVER_ART is hascoverart Individual album property keys can be enabled/disabled using enablealbumpropertykeyxxxx for each raw key General code cleanup, fixes and optimizations