### PR TITLE
#680 Submodule `master` updated to Tidal Plugin 0.8.13

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ release|subsonic|0.9.9
 release|tidal|0.8.12
 release|mother earth radio|0.0.5
 master|subsonic|0.9.15
-master|tidal|0.8.12
+master|tidal|0.8.13
 master|mother earth radio|0.0.5
 edge|subsonic|0.9.15
 edge|tidal|0.8.13

--- a/doc/change-history.md
+++ b/doc/change-history.md
@@ -2,7 +2,8 @@
 
 Change Date|Major Changes
 ---|---
-2026-07-10|Submodule `edge` updated to Tidal Plugin 0.8.13
+2026-07-13|Submodule `master` updated to Tidal Plugin 0.8.13 (see [#680](https://github.com/GioF71/upmpdcli-docker/issues/680))
+2026-07-10|Submodule `edge` updated to Tidal Plugin 0.8.13 (see [#680](https://github.com/GioF71/upmpdcli-docker/issues/680))
 2026-07-04|Submodule `master` updated to Subsonic Plugin 0.9.15 (see [#678](https://github.com/GioF71/upmpdcli-docker/issues/678))
 2026-07-02|Submodule `edge` updated to Subsonic Plugin 0.9.15 (see [#676](https://github.com/GioF71/upmpdcli-docker/issues/676))
 2026-05-12|Information for retrieving a PKCE credentials file (see [#672](https://github.com/GioF71/upmpdcli-docker/issues/672))


### PR DESCRIPTION
Tidal Plugin Release 0.8.13

- Review tidal plugin initialization process
- Favorite album preloading (speeds up showing album container especially if favorite actions are allowed)
- Image for Page selection entries are now preloaded
- Misc code corrections, cleanup and refactoring
- Performance improvements on initial view (does not load playlists twice)
- Show container type and id (Album, Playlist, etc) in output from build_intermediate_url (if enabled)
- Add timestamps in log entries
- Misc code corrections, cleanup and refactoring