### PR TITLE
Submodule `edge` and `master` updated to Tidal Plugin 0.8.131

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ BUILD_TYPE|PLUGIN|VERSION
 release|subsonic|0.9.9
 release|tidal|0.8.12
 release|mother earth radio|0.0.5
-master|subsonic|0.9.15
-master|tidal|0.8.13
+master|subsonic|0.9.15.1
+master|tidal|0.8.13.1
 master|mother earth radio|0.0.5
 edge|subsonic|0.9.15.1
 edge|tidal|0.8.13.1

--- a/doc/change-history.md
+++ b/doc/change-history.md
@@ -2,6 +2,7 @@
 
 Change Date|Major Changes
 ---|---
+2026-07-16|Submodule `edge` and `master` updated to Tidal Plugin 0.8.131 (see [this issue](https://github.com/GioF71/audio-tools/issues/4))
 2026-07-13|Submodule `master` updated to Tidal Plugin 0.8.13 (see [#680](https://github.com/GioF71/upmpdcli-docker/issues/680))
 2026-07-10|Submodule `edge` updated to Tidal Plugin 0.8.13 (see [#680](https://github.com/GioF71/upmpdcli-docker/issues/680))
 2026-07-04|Submodule `master` updated to Subsonic Plugin 0.9.15 (see [#678](https://github.com/GioF71/upmpdcli-docker/issues/678))


### PR DESCRIPTION
- Also fixed issue caused to the subsonic plugin (bumped to a .1 release)